### PR TITLE
feat/Remove rewarded interstitial references on android plugin

### DIFF
--- a/Source/Android/src/main/java/com/applovin/godot/AppLovinMAXGodotPlugin.java
+++ b/Source/Android/src/main/java/com/applovin/godot/AppLovinMAXGodotPlugin.java
@@ -201,33 +201,6 @@ public class AppLovinMAXGodotPlugin
                                      Dictionary.class,
                                      Dictionary.class ) );
 
-        signals.add( new SignalInfo( Signal.REWARDED_INTERSTITIAL_ON_AD_LOADED,
-                                     String.class,
-                                     Dictionary.class ) );
-        signals.add( new SignalInfo( Signal.REWARDED_INTERSTITIAL_ON_AD_LOAD_FAILED,
-                                     String.class,
-                                     Dictionary.class ) );
-        signals.add( new SignalInfo( Signal.REWARDED_INTERSTITIAL_ON_AD_CLICKED,
-                                     String.class,
-                                     Dictionary.class ) );
-        signals.add( new SignalInfo( Signal.REWARDED_INTERSTITIAL_ON_AD_REVENUE_PAID,
-                                     String.class,
-                                     Dictionary.class ) );
-        signals.add( new SignalInfo( Signal.REWARDED_INTERSTITIAL_ON_AD_DISPLAYED,
-                                     String.class,
-                                     Dictionary.class ) );
-        signals.add( new SignalInfo( Signal.REWARDED_INTERSTITIAL_ON_AD_DISPLAY_FAILED,
-                                     String.class,
-                                     Dictionary.class,
-                                     Dictionary.class ) );
-        signals.add( new SignalInfo( Signal.REWARDED_INTERSTITIAL_ON_AD_HIDDEN,
-                                     String.class,
-                                     Dictionary.class ) );
-        signals.add( new SignalInfo( Signal.REWARDED_INTERSTITIAL_ON_AD_RECEIVED_REWARD,
-                                     String.class,
-                                     Dictionary.class,
-                                     Dictionary.class ) );
-
         return signals;
     }
 
@@ -643,40 +616,6 @@ public class AppLovinMAXGodotPlugin
     public void set_rewarded_ad_local_extra_parameter(String adUnitId, String key, Object value)
     {
         appLovinMAX.setRewardedAdLocalExtraParameter( adUnitId.trim(), key, value );
-    }
-
-    //endregion
-
-    //region Rewarded Interstitial
-
-    @UsedByGodot
-    public void load_rewarded_interstitial(String adUnitId)
-    {
-        appLovinMAX.loadRewardedInterstitialAd( adUnitId.trim() );
-    }
-
-    @UsedByGodot
-    public boolean is_rewarded_interstitial_ready(String adUnitId)
-    {
-        return appLovinMAX.isRewardedInterstitialAdReady( adUnitId.trim() );
-    }
-
-    @UsedByGodot
-    public void show_rewarded_interstitial(String adUnitId, String placement, String customData)
-    {
-        appLovinMAX.showRewardedInterstitialAd( adUnitId.trim(), placement, customData );
-    }
-
-    @UsedByGodot
-    public void set_rewarded_interstitial_extra_parameter(String adUnitId, String key, String value)
-    {
-        appLovinMAX.setRewardedInterstitialAdExtraParameter( adUnitId.trim(), key, value );
-    }
-
-    @UsedByGodot
-    public void set_rewarded_interstitial_local_extra_parameter(String adUnitId, String key, Object value)
-    {
-        appLovinMAX.setRewardedInterstitialAdLocalExtraParameter( adUnitId.trim(), key, value );
     }
 
     //endregion

--- a/Source/Android/src/main/java/com/applovin/godot/Signal.java
+++ b/Source/Android/src/main/java/com/applovin/godot/Signal.java
@@ -42,14 +42,5 @@ public class Signal
     public static String REWARDED_ON_AD_DISPLAY_FAILED = "rewarded_on_ad_display_failed";
     public static String REWARDED_ON_AD_HIDDEN = "rewarded_on_ad_hidden";
     public static String REWARDED_ON_AD_RECEIVED_REWARD = "rewarded_on_ad_received_reward";
-
-    public static String REWARDED_INTERSTITIAL_ON_AD_LOADED = "rewarded_interstitial_on_ad_loaded";
-    public static String REWARDED_INTERSTITIAL_ON_AD_LOAD_FAILED = "rewarded_interstitial_on_ad_load_failed";
-    public static String REWARDED_INTERSTITIAL_ON_AD_CLICKED = "rewarded_interstitial_on_ad_clicked";
-    public static String REWARDED_INTERSTITIAL_ON_AD_REVENUE_PAID = "rewarded_interstitial_on_ad_revenue_paid";
-    public static String REWARDED_INTERSTITIAL_ON_AD_DISPLAYED = "rewarded_interstitial_on_ad_displayed";
-    public static String REWARDED_INTERSTITIAL_ON_AD_DISPLAY_FAILED = "rewarded_interstitial_on_ad_display_failed";
-    public static String REWARDED_INTERSTITIAL_ON_AD_HIDDEN = "rewarded_interstitial_on_ad_hidden";
-    public static String REWARDED_INTERSTITIAL_ON_AD_RECEIVED_REWARD = "rewarded_interstitial_on_ad_received_reward";
 }
 


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Remove all references to `rewarded interstitial` ads from the Android plugin, specifically in `AppLovinMAXGodotManager.java`, `AppLovinMAXGodotPlugin.java`, and `Signal.java`.

### Why are these changes being made?
This change is necessary due to the obsolescence of `rewarded interstitial` ads on the Android platform. These ads are no longer supported or needed, streamlining the codebase and improving maintainability by eliminating deprecated functionality.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->